### PR TITLE
@W-10349190: fix pgbouncer test on heroku-22 stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby '3.0.0'
+ruby '3.1.2'
 
 gem "pg"
 gem "sequel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 3.0.0p0
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.2.6


### PR DESCRIPTION
Updates the Ruby version used by this application to one that is available on the heroku-22 stack (`3.1.2`)